### PR TITLE
0.9.22: Increment build number after current maximum build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - patches/Makefile.patch
 
 build:
-  number: 0
+  number: 1001
   run_exports:
     - {{ pin_subpackage("lmdb", max_pin="x.x.x") }}
 


### PR DESCRIPTION
### Context

LMBD 0.9.22 was packaged for Linux and OSX but was not for Windows in the past.

LMDB 0.9.22 has been recently packaged for Windows by the job triggered by: 486095133fe93336d7c0d9184d923085dfe8054f.

Is it accessible on conda-forge, yet it is note resolvable for Windows, one stil get: " nothing provides requested lmdb 0.9.22.*". For instance see:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=715611&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213&l=132

The last build number for the Linux and OSX builds for 0.9.22 surprisingly is 1000.

See: https://anaconda.org/conda-forge/lmdb/files

 	conda 	222.0 kB 	| osx-64/lmdb-0.9.22-h1de35cc_1000.tar.bz2 	 4 years and 6 months ago 	conda-forge 	615 	main gcc7 cf202003
	conda 	670.8 kB 	| linux-64/lmdb-0.9.22-h14c3975_1000.tar.bz2 	 4 years and 6 months ago 	conda-forge 	3841 	main gcc7 cf202003

### Proposed solution

This updates the build number to 1001 for uniformity, hopefully making lmdb 0.9.22 resolvable for Windows.

cc @h-vetinari.

---

```
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.